### PR TITLE
Removes body-parser & session deprecation warnings

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,8 +55,14 @@ passport.deserializeUser(function(user, done) {
   Setup the Express app
 */
 app.use(cookieParser('cookie_secret_shh')); // Change for production apps
-app.use(bodyParser());
-app.use(session({secret: 'session_secret_shh'})); // Change for production apps
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
+app.use(session({
+  secret: 'session_secret_shh', // Change for production apps
+  resave: true,
+  saveUninitialized: false
+}));
 app.use(passport.initialize());
 app.use(passport.session());
 


### PR DESCRIPTION
```sh
express-session deprecated undefined resave option; provide resave option
express-session deprecated undefined saveUninitialized option; provide saveUninitialized option
body-parser deprecated bodyParser: use individual json/urlencoded middlewares
body-parser deprecated undefined extended: provide extended option
```